### PR TITLE
fix: install libc6-compat to fix missing ld-linux-x86-64.so.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-metadata
 node_modules
 Gemfile.lock
+.jekyll-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM jekyll/jekyll:latest
+
+RUN apk update
+RUN apk add --no-cache libc6-compat
+RUN ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 jekyll:
-    image: jekyll/jekyll:latest
-    command: bash -c "apk update && apk add --no-cache libc6-compat && ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2 && jekyll serve --force_polling"
+    build: .
+    command: jekyll serve --force_polling
     ports:
         - 4000:4000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 jekyll:
     image: jekyll/jekyll:latest
-    command: jekyll serve --force_polling
+    command: bash -c "apk update && apk add --no-cache libc6-compat && ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2 && jekyll serve --force_polling"
     ports:
         - 4000:4000
     volumes:


### PR DESCRIPTION
This fixes the error I got when starting the container:

<details>
<summary>Log</summary>

```
jekyll_1  | /usr/local/bundle/gems/ffi-1.11.1/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library '/usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc/libsass.so': Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc/libsass.so) (LoadError)
jekyll_1  |     from /usr/local/bundle/gems/ffi-1.11.1/lib/ffi/library.rb:99:in `map'
jekyll_1  |     from /usr/local/bundle/gems/ffi-1.11.1/lib/ffi/library.rb:99:in `ffi_lib'
jekyll_1  |     from /usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc/native.rb:10:in `<module:Native>'
jekyll_1  |     from /usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc/native.rb:6:in `<module:SassC>'
jekyll_1  |     from /usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc/native.rb:5:in `<top (required)>'
jekyll_1  |     from /usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc.rb:31:in `require_relative'
jekyll_1  |     from /usr/local/bundle/gems/sassc-2.1.0-x86_64-linux/lib/sassc.rb:31:in `<top (required)>'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-sass-converter-2.0.0/lib/jekyll/converters/scss.rb:3:in `require'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-sass-converter-2.0.0/lib/jekyll/converters/scss.rb:3:in `<top (required)>'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-sass-converter-2.0.0/lib/jekyll-sass-converter.rb:4:in `require'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-sass-converter-2.0.0/lib/jekyll-sass-converter.rb:4:in `<top (required)>'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-4.0.0/lib/jekyll.rb:206:in `require'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-4.0.0/lib/jekyll.rb:206:in `<top (required)>'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-4.0.0/exe/jekyll:8:in `require'
jekyll_1  |     from /usr/local/bundle/gems/jekyll-4.0.0/exe/jekyll:8:in `<top (required)>'
jekyll_1  |     from /usr/local/bundle/bin/jekyll:29:in `load'
jekyll_1  |     from /usr/local/bundle/bin/jekyll:29:in `<main>'
tech-womengithubio_jekyll_1 exited with code 1
```

</details>