### PR TITLE
Link to the english registration page on Meetup

### DIFF
--- a/_pages/ada-lovelace-day-2019.md
+++ b/_pages/ada-lovelace-day-2019.md
@@ -19,7 +19,7 @@ During the conference 8 women will give hands-on talks about their work and fiel
 
 ## Registration
 
-<a href="https://www.meetup.com/de-DE/Tech-Women-Norway/events/264108718/" class="btn btn-dark">Register here</a>
+<a href="https://www.meetup.com/Tech-Women-Norway/events/264108718/" class="btn btn-dark">Register here</a>
 
 _Note: The event is now full and new folks are being added to the waiting list._
 


### PR DESCRIPTION
The link was pointing to the german version of the meetup site.
Changed it to not specify a languge in the url. Probably defaulting to en-US or perhaps user preference.