### PR TITLE
feat: add code of conduct

### DIFF
--- a/_includes/menu-header.html
+++ b/_includes/menu-header.html
@@ -1,9 +1,6 @@
 <!--  Replace menu links here -->
 
 <li class="nav-item">
-<a class="nav-link" href="{{site.baseurl}}/index.html">Home</a>
-</li>
-<li class="nav-item">
 <a class="nav-link" href="{{site.baseurl}}/ada-lovelace-day-2019.html">Ada Lovelace Day</a>
 </li>
 <li class="nav-item">
@@ -11,4 +8,7 @@
 </li>
 <li class="nav-item">
 <a class="nav-link" href="{{site.baseurl}}/contact.html">Contact</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="{{site.baseurl}}/code-of-conduct/">Code of Conduct</a>
 </li>

--- a/_pages/ada-lovelace-day-2019.md
+++ b/_pages/ada-lovelace-day-2019.md
@@ -9,7 +9,9 @@ Welcome to the _Ada Lovelace mini-conference_ and the presentation of the [_2019
 During the conference 8 women will give hands-on talks about their work and fields.
 
 **When**: 8th October 2019, 8:20-13:00  
-**Location**: [Youngs gate 7, 0181 Oslo, Norway](https://goo.gl/maps/E5re8jL5EGzmPW5R7) at Blank AS offices
+**Location**: [Youngs gate 7, 0181 Oslo, Norway](https://goo.gl/maps/E5re8jL5EGzmPW5R7) at Blank AS offices  
+
+All attendees of our events are required to agree with our [Code of Conduct](/code-of-conduct/). This Code of Conduct applies not only to our events but to all digital spaces that are operated by us, such as GitHub.
 
 > Nominations for the Role Models list are open!
 > Please use [this form](https://forms.gle/jCMJEj5HcTzs5p8JA) to propose Tech Role Models.

--- a/_pages/code-of-conduct/attendee-incident-handling-procedure.md
+++ b/_pages/code-of-conduct/attendee-incident-handling-procedure.md
@@ -1,0 +1,54 @@
+---
+title: "Code of Conduct: Attendee Procedure for Incident Handling"
+permalink: "/code-of-conduct/attendee-incident-handling-procedure"
+---
+
+<ol>
+<li>
+
+Keep in mind that all conference staff will be wearing a t-shirt which clearly identifies them as staff. The staff will also be prepared to handle the incident.
+All of our staff are informed of the [Code of Conduct](/code-of-conduct/) and procedure
+for handling harassment at the conference. _There will be a mandatory staff meeting onsite at the conference
+when this will be reiterated._
+
+</li>
+<li>
+
+Report the harassment incident (preferably in writing) to a conference staff member. All reports
+are confidential. Please do not disclose public information about the incident until the staff have
+had sufficient time in which to address the situation. This is as much for your safety and protection
+as it is the other attendees.  
+ When reporting the event to staff, try to gather as much information as available but do not
+interview people about the incident. Staff will assist you in writing the report/collecting information.
+
+The important information consists of:
+
+- Identifying information (name/social media username/company name) of the participant doing the harassing
+- The behavior that was in violation
+- The approximate time of the behavior (if different than the time the report was made)
+- The circumstances surrounding the incident
+- Other people involved in the incident
+
+The staff is well informed on how to deal with the incident and how to further proceed with the situation.
+
+</li>
+<li>
+
+If everyone is presently physically safe, involve law enforcement or security only at a victim's request.
+If you do feel your safety in jeopardy please do not hesitate to contact local law enforcement by
+dialing 112. If you do not have a cell phone, you can use any hotel phone or simply ask a staff member.
+
+</li>
+</ol>
+
+**Note**: Incidents that violate the Code of Conduct are extremely damaging to the community, and they
+will not be tolerated. The silver lining is that, in many cases, these incidents present a chance for
+the offenders, and the community at large, to grow, learn, and become better. We request
+to be your first resource when reporting a _Tech Women Norway_-related incident, so that we may enforce
+the Code of Conduct and take quick action toward a resolution.
+
+If at all possible, all reports should be made directly to [{{ site.email }}](mailto:{{ site.email }}) or through the [contact form](/contact.html).
+
+#### Acknowledgments
+
+This Attendee Procedure for Incident Handling is based on the [Attendee Procedure for Incident Handling of CppCon](https://github.com/CppCon/CppConCodeOfConduct/blob/master/Attendee%20Procedure%20for%20incident%20handling.md), which itself is based on the Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)".

--- a/_pages/code-of-conduct/index.md
+++ b/_pages/code-of-conduct/index.md
@@ -1,0 +1,57 @@
+---
+title: "Code of Conduct"
+permalink: "/code-of-conduct"
+---
+
+> All attendees of our events are required to agree with the following Code of Conduct. This Code of Conduct applies not only to our events but to all digital spaces that are operated by us, such as GitHub.
+
+_Tech Women Norway_ is a yearly event to celebrate Norwegian women and gender queer people that are Individual Contributors in tech on Ada Lovelace Day Oct 8th.
+
+We value the participation of everyone who wants to celebrate with us and want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the conference and at all conference events, whether officially sponsored by _Tech Women Norway_ or not.
+
+To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any _Tech Women Norway_ event are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the event.
+
+#### The Short Version
+
+_Tech Women Norway_ is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form.
+
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate for any conference venue, including talks.
+
+Be kind to others. Do not insult or put down other attendees. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for _Tech Women Norway_.
+
+Attendees violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.
+
+Thank you for helping make this a welcoming, friendly event for all.
+
+#### The Longer Version
+
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for _Tech Women Norway_.
+
+If a participant engages in behavior that violates this Code of Conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+
+##### Procedure for Handling Harassment
+
+- [Attendee Procedure for incident handling](Attendee%20Procedure%20for%20incident%20handling.md)
+- [Staff Procedure for incident handling](Staff%20Procedure%20for%20incident%20handling.md)
+
+#### Contact Information
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Conference staff will be wearing "_Tech Women Norway_" t-shirts.
+
+If the matter is especially urgent, please contact any of these individuals:
+
+- Patricia Aas at [psmaas@gmail.com](mailto:psmaas@gmail.com)
+
+You may also send an email to [{{ site.email }}](mailto:{{ site.email }}) or use the [contact form](/contact.html).
+
+Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+#### Acknowledgments
+
+This anti-harassment policy is based on the [Code of Conduct of CppCon](https://github.com/CppCon/CppConCodeOfConduct/blob/master/code_of_conduct.md), which itself is based on [the example policy from the Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy), created by the Ada Initiative and other volunteers.

--- a/_pages/code-of-conduct/staff-incident-handling-procedure.md
+++ b/_pages/code-of-conduct/staff-incident-handling-procedure.md
@@ -1,0 +1,69 @@
+---
+title: "Code of Conduct: Staff Procedure for Incident Handling"
+permalink: "/code-of-conduct/staff-incident-handling-procedure"
+---
+
+Be sure to have a good understanding of our Code of Conduct, which can be found here: [Code of Conduct](/code-of-conduct/).
+
+Also have a good understanding of what is expected from an attendee that wants to report a harassment incident. These guidelines can be found [here](/code-of-conduct/attendee-incident-handling-procedure).
+
+Try to get as much of the incident in written form by the reporter. If you cannot, transcribe it yourself as it was told to you. The important information to gather include the following:
+
+- Identifying information (name/social media username/company name) of the participant doing the harassing
+- The behavior that was in violation
+- The approximate time of the behavior (if different than the time the report was made)
+- The circumstances surrounding the incident
+- Other people involved in the incident
+
+Prepare an initial response to the incident. This initial response is very important and will set the tone for _Tech Women Norway_. Depending on the severity/details of the incident, please follow these guidelines:
+
+- If there is any general threat to attendees or the safety of anyone including conference staff is in doubt, summon security or police
+- Offer the victim a private place to sit
+- Ask "is there a friend or trusted person who you would like to be with you?" (if so, arrange for someone to fetch this person)
+- Ask them "how can I help?"
+- Provide them with your list of emergency contacts if they need help later
+- If everyone is presently physically safe, involve law enforcement or security only at a victim's request
+
+There are also some guidelines as to what not to do as an initial response:
+
+- Do not overtly invite them to withdraw the complaint or mention that withdrawal is OK. This suggests that you want them to do so, and is therefore coercive. "If you're OK with it [and keep pursuing the complaint]" suggests that you are by default pursuing it and is not coercive.
+- Do not ask for their advice on how to deal with the complaint. This is a staff responsibility.
+- Do not offer them input into penalties. This is the staff's responsibility.
+
+Once something is reported to a staff member, immediately meet with Patricia Aas (conference chair). The main objectives of this meeting is to find out the following:
+
+- What happened?
+- Are we doing anything about it?
+- Who is doing those things?
+- When are they doing them?
+
+After the staff meeting and discussion, have a staff member (preferably the conference chair or event coordinator if available) communicate with the alleged harasser. Make sure to inform them of what has been reported about them.
+
+Allow the alleged harasser to give their side of the story to the staff. After this point, if the report stands, let the alleged harasser know what actions will be taken against them.
+
+Some things for the staff to consider when dealing with Code of Conduct offenders:
+
+- Warning the harasser to cease their behavior and that any further reports will result in sanctions
+- Requiring that the harasser avoid any interaction with, and physical proximity to, their victim for the remainder of the event
+- Ending a talk that violates the policy early
+- Not publishing the video or slides of a talk that violated the policy
+- Not allowing a speaker who violated the policy to give (further) talks at the event now or in the future
+- Immediately ending any event volunteer responsibilities and privileges the harasser holds
+- Requiring that the harasser not volunteer for future events your organization runs (either indefinitely or for a certain time period)
+- Requiring that the harasser refund any travel grants and similar they received (this would need to be a condition of the grant at the time of being awarded)
+- Requiring that the harasser immediately leave the event and not return
+- Banning the harasser from future events (either indefinitely or for a certain time period)
+- Removing a harasser from membership of relevant organizations
+- Publishing an account of the harassment and calling for the resignation of the harasser from their responsibilities (usually pursued by people without formal authority: may be called for if the harasser is the event leader, or refuses to stand aside from the conflict of interest, or similar, typically event staff have sufficient governing rights over their space that this isn't as useful)
+
+Give accused attendees a place to appeal to if there is one, but in the meantime the report stands. Keep in mind that it is not a good idea to encourage an apology from the harasser.
+
+It is very important how we deal with the incident publicly. Our policy is to make sure that everyone aware of the initial incident is also made aware that it is not according to policy and that official action has been taken - while still respecting the privacy of individual attendees. When speaking to individuals (those who are aware of the incident, but were not involved with the incident) about the incident it is a good idea to keep the details out.
+
+Depending on the incident, Patricia Aas (conference chair) may decide to make one or more public announcements. If necessary, this will be done with a short announcement either during the plenary and/or through other channels. No one other than the conference chair or someone delegated authority from the conference chair should make any announcements. No personal information about either party will be disclosed as part of this process.
+
+If some attendees were angered by the incident, it is best to apologize to them that the incident occurred to begin with. If there are residual hard feelings, suggest to them to write an email to the conference chair or to the event coordinator. It will be dealt with accordingly.
+
+#### Acknowledgments
+
+This Staff Procedure for Incident Handling is based on the [Staff Procedure for Incident Handling of CppCon](https://github.com/CppCon/CppConCodeOfConduct/blob/master/Staff%20Procedure%20for%20incident%20handling.md), which itself is based on the Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)".

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -121,7 +121,11 @@ dd {
   margin-left: 0; }
 
 blockquote {
-  margin: 0 0 1rem; }
+  margin: 0 0 1rem;
+  border-left: 2px solid #ccc;
+  padding-left: 1rem;
+  color: #00000099;
+}
 
 dfn {
   font-style: italic; }


### PR DESCRIPTION
I've adapted the Code of Conducted for use at Tech Women Norway events.

I added you @patricia-gallardo as the main point of contact (in addition with the techwomen.no@gmail.com email / the contact form).

One thing that might need to be adapted is how to identify staff members during the event: 
> "Conference staff will be wearing "_Tech Women Norway_" t-shirts." 

[source](https://github.com/tech-women/tech-women.github.io/compare/code-of-conduct?expand=1#diff-7ad14a8fd9f9637d3c07a09a5148e2f0R45)

Fixes #10