### PR TITLE
Fix links in the Code of Conduct page

### DIFF
--- a/_pages/code-of-conduct/index.md
+++ b/_pages/code-of-conduct/index.md
@@ -37,8 +37,8 @@ If a participant engages in behavior that violates this Code of Conduct, the con
 
 ##### Procedure for Handling Harassment
 
-- [Attendee Procedure for incident handling](Attendee%20Procedure%20for%20incident%20handling.md)
-- [Staff Procedure for incident handling](Staff%20Procedure%20for%20incident%20handling.md)
+- [Attendee Procedure for incident handling](attendee-incident-handling-procedure.html)
+- [Staff Procedure for incident handling](staff-incident-handling-procedure.html)
 
 #### Contact Information
 


### PR DESCRIPTION
Hello!

Was just reading what seems to be an amazing program for Ada Lovelace Day, and happened to find a couple of broken links on the code of conduct page.

Here is a PR fixing those.

Thanks, keep up the great work!