### PR TITLE
Use jekyll relative URLs for code of conduct links

### DIFF
--- a/_pages/code-of-conduct/index.md
+++ b/_pages/code-of-conduct/index.md
@@ -37,8 +37,8 @@ If a participant engages in behavior that violates this Code of Conduct, the con
 
 ##### Procedure for Handling Harassment
 
-- [Attendee Procedure for incident handling](./attendee-incident-handling-procedure)
-- [Staff Procedure for incident handling](./staff-incident-handling-procedure)
+- [Attendee Procedure for incident handling]({{ '/code-of-conduct/attendee-incident-handling-procedure.html' | relative_url }})
+- [Staff Procedure for incident handling]({{ '/code-of-conduct/staff-incident-handling-procedure.html' | relative_url }})
 
 #### Contact Information
 


### PR DESCRIPTION
Good morning!

I see my fix from yesterday (#17) did not work on github pages. Neither did the fix in a followup from that. Here is a more "native" fix for it.